### PR TITLE
Hide public editorial/artist content while preserving CMS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ SUPABASE_INVITE_REDIRECT_URL=https://firesidetribe.com/admin/login
 
 Use the exact domain for each environment (localhost, staging, production) so new teammates land on the right app after accepting their invitation.
 
+## Public Content Visibility Switches
+
+The public site now supports non-destructive content hiding for editorial and artist pages. Data remains in the CMS/admin, but public routes and nav links can be switched off.
+
+Environment flags:
+
+```bash
+NEXT_PUBLIC_SHOW_EPISODES_CONTENT=true
+NEXT_PUBLIC_SHOW_ARTISTS_CONTENT=false
+NEXT_PUBLIC_SHOW_BLOG_CONTENT=false
+```
+
+Defaults if unset:
+
+1. Episodes: visible
+2. Artists: hidden
+3. Blog/Editorial: hidden
+
 ## Development
 
 ```bash

--- a/app/artists/[slug]/page.tsx
+++ b/app/artists/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image"
 import Link from "next/link"
-import { ArrowLeft, Youtube, Instagram, Twitter } from "lucide-react"
-import { getAssetUrl } from "@/lib/utils/assets"
+import { ArrowLeft } from "lucide-react"
+import { notFound } from "next/navigation"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
+import { getArtistBySlug } from "@/lib/repositories/content"
 
 interface ArtistPageProps {
   params: {
@@ -9,214 +11,78 @@ interface ArtistPageProps {
   }
 }
 
-export default function ArtistPage({ params }: ArtistPageProps) {
-  // In a real app, you would fetch the artist data based on the slug
-  // For this example, we'll use hardcoded data
+const normalizeBio = (value: unknown): string[] => {
+  if (!value) return []
 
-  const artists = {
-    tayc: {
-      name: "Tayc",
-      fullName: "Julien Bouadjie",
-      bio: `
-        <p class="mb-4">
-          Tayc, born Julien Bouadjie to Cameroonian parents in Marseille, France, has emerged as one of the most exciting voices in French R&B. His music beautifully fuses African rhythms, particularly those from Cameroon, with contemporary R&B and Afrobeats.
-        </p>
-        
-        <p class="mb-4">
-          With his smooth vocals, often switching between French and occasional phrases in Cameroonian dialects, Tayc has created a signature style that's captivating audiences across Europe and beyond. His breakthrough came with the album "NYXIA," which showcased his unique sound and cemented his place in the French music scene.
-        </p>
-        
-        <p class="mb-4">
-          What sets Tayc apart is his deliberate incorporation of his Cameroonian roots. While many artists with African heritage might dilute these influences to appeal to mainstream European audiences, Tayc embraces them, creating a sound that feels authentic and fresh.
-        </p>
-        
-        <p class="mb-4">
-          His hit singles like "N'y pense plus" feature subtle Bikutsi rhythms, a traditional music style from Cameroon, while "Le temps" incorporates elements of Makossa, another Cameroonian genre made famous by artists like Manu Dibango.
-        </p>
-      `,
-      imageSrc: getAssetUrl("images/tayc-2.jpeg"),
-      spotifyUrl: "https://open.spotify.com/artist/0BlSV1sY8ePR5nj1tDmvXY",
-      youtubeUrl: "https://www.youtube.com/channel/UCrPLMg2zy1xFOdLUsDg8aTw",
-      instagramUrl: "https://www.instagram.com/taycofficial",
-      twitterUrl: "https://twitter.com/taycofficial",
-      popularSongs: ["N'y pense plus", "Le temps", "Pas besoin", "Moi je prouve", "Comme toi"],
-    },
-    "james-bks": {
-      name: "James BKS",
-      fullName: "James Edjouma",
-      bio: `
-        <p class="mb-4">
-          James BKS, born James Edjouma, is a producer, composer, and musician who has forged his own path in music while honoring the legacy of his father, legendary Cameroonian saxophonist and composer Manu Dibango.
-        </p>
-        
-        <p class="mb-4">
-          What makes James BKS's story particularly interesting is that he didn't grow up with Dibango. Raised in France by his mother and adoptive father, James only connected with Manu Dibango as an adult, after already establishing himself in the music industry.
-        </p>
-        
-        <p class="mb-4">
-          As a producer, James has worked with the likes of Diddy, Talib Kweli, and French rapper Booba. This reunion with his biological father sparked a musical rebirth for James. While he had been successful producing hip-hop in the United States, reconnecting with Dibango inspired him to explore his Cameroonian roots and incorporate African sounds into his production.
-        </p>
-        
-        <p class="mb-4">
-          James BKS's music serves as a bridge between generations and genres. His track "Kwele," featuring Dibango himself alongside Allan Kingdom and Manu's longtime collaborator Marthe, perfectly exemplifies this fusion of traditional Cameroonian elements with contemporary production techniques.
-        </p>
-        
-        <p class="mb-4">
-          Through his label Grown Kid Records, James continues to develop artists and projects that blend African musical traditions with global sounds, much as his father did with his groundbreaking hit "Soul Makossa" in the 1970s.
-        </p>
-      `,
-      imageSrc: getAssetUrl("images/james-bks.jpg"),
-      spotifyUrl: "https://open.spotify.com/artist/0BlSV1sY8ePR5nj1tDmvXY",
-      youtubeUrl: "https://www.youtube.com/channel/UCrPLMg2zy1xFOdLUsDg8aTw",
-      instagramUrl: "https://www.instagram.com/jamesbks",
-      twitterUrl: "https://twitter.com/jamesbks",
-      popularSongs: ["Kwele", "New Breed", "Kusema", "Jungle Go", "Pouvoir"],
-    },
-    yame: {
-      name: "Yame",
-      fullName: "Yame Njock",
-      bio: `
-        <p class="mb-4">
-          Yame has been steadily building a reputation for soulful vocals and thoughtful songwriting. Based between Paris and Douala, her music explores themes of identity and belonging, resonating with the Cameroonian diaspora worldwide.
-        </p>
-        
-        <p class="mb-4">
-          Growing up in a musical family in Douala, Yame was exposed to a rich variety of sounds from an early age. Traditional Cameroonian music played alongside American R&B and French pop in her household, creating the foundation for her eclectic musical style.
-        </p>
-        
-        <p class="mb-4">
-          After moving to Paris to pursue her education, Yame began performing in local venues and quickly caught the attention of music producers impressed by her powerful voice and authentic songwriting. Her EP "Roots & Wings" received critical acclaim for its authentic blend of contemporary R&B with subtle nods to Bikutsi rhythms.
-        </p>
-        
-        <p class="mb-4">
-          What sets Yame apart is her ability to weave stories of the diaspora experience into her music, creating songs that speak to the complexities of identity and belonging. Her lyrics, often switching between French, English, and her native dialect, reflect the multilingual reality of many young Cameroonians today.
-        </p>
-        
-        <p class="mb-4">
-          As her international profile continues to grow, Yame remains committed to highlighting Cameroonian culture and creating pathways for other artists from her homeland to reach global audiences.
-        </p>
-      `,
-      imageSrc: getAssetUrl("images/yame.jpg"),
-      spotifyUrl: "https://open.spotify.com/artist/0BlSV1sY8ePR5nj1tDmvXY",
-      youtubeUrl: "https://www.youtube.com/channel/UCrPLMg2zy1xFOdLUsDg8aTw",
-      instagramUrl: "https://www.instagram.com/yameofficial",
-      twitterUrl: "https://twitter.com/yameofficial",
-      popularSongs: ["Roots & Wings", "Douala to Paris", "Remember Me", "Homeland", "Identity"],
-    },
+  if (typeof value === "string") {
+    return value
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean)
   }
 
-  const artist = artists[params.slug]
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => normalizeBio(item))
+  }
 
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap((item) => normalizeBio(item))
+  }
+
+  return []
+}
+
+export default async function ArtistPage({ params }: ArtistPageProps) {
+  if (!publicContentVisibility.artists) {
+    notFound()
+  }
+
+  const artist = await getArtistBySlug(params.slug)
   if (!artist) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold mb-4">Artist Not Found</h1>
-          <Link href="/artists" className="text-blue-600 hover:underline">
-            Back to Artists
-          </Link>
-        </div>
-      </div>
-    )
+    notFound()
   }
+
+  const bioParagraphs = normalizeBio(artist.bio)
+  const description = bioParagraphs.length > 0 ? bioParagraphs : [artist.shortDescription].filter(Boolean)
 
   return (
-    <div className="min-h-screen bg-blue-100 py-12 px-4">
-      <div className="max-w-4xl mx-auto">
+    <div className="min-h-screen bg-background py-12 px-4">
+      <div className="max-w-5xl mx-auto">
         <Link
           href="/artists"
-          className="inline-flex items-center gap-2 mb-8 font-bold hover:text-blue-600 transition-colors"
+          className="inline-flex items-center gap-2 mb-8 text-sm uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
         >
-          <ArrowLeft size={20} />
+          <ArrowLeft size={16} />
           Back to Artists
         </Link>
 
-        <div className="bg-white border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <article className="bg-card border border-border rounded-lg p-8 md:p-12">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
             <div className="md:col-span-1">
-              <div className="relative h-[300px] border-4 border-black overflow-hidden">
-                <Image src={artist.imageSrc || "/placeholder.svg"} alt={artist.name} fill className="object-cover" />
-              </div>
-
-              <div className="mt-6 space-y-4">
-                <h2 className="text-xl font-bold">Connect</h2>
-
-                <div className="flex flex-col gap-3">
-                  <a
-                    href={artist.spotifyUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 hover:text-green-600 transition-colors"
-                  >
-                    <span>Spotify</span>
-                  </a>
-
-                  <a
-                    href={artist.youtubeUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 hover:text-red-600 transition-colors"
-                  >
-                    <Youtube size={20} />
-                    <span>YouTube</span>
-                  </a>
-
-                  <a
-                    href={artist.instagramUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 hover:text-purple-600 transition-colors"
-                  >
-                    <Instagram size={20} />
-                    <span>Instagram</span>
-                  </a>
-
-                  <a
-                    href={artist.twitterUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 hover:text-blue-400 transition-colors"
-                  >
-                    <Twitter size={20} />
-                    <span>Twitter</span>
-                  </a>
-                </div>
-              </div>
-
-              <div className="mt-6 space-y-4">
-                <h2 className="text-xl font-bold">Popular Songs</h2>
-
-                <ul className="space-y-2">
-                  {artist.popularSongs.map((song, index) => (
-                    <li key={index} className="flex items-center gap-2">
-                      <span>{song}</span>
-                    </li>
-                  ))}
-                </ul>
+              <div className="relative h-[320px] overflow-hidden rounded-md border border-border">
+                <Image
+                  src={artist.profileImageUrl || "/placeholder.svg"}
+                  alt={artist.profileImageAlt || artist.name}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 300px"
+                />
               </div>
             </div>
 
             <div className="md:col-span-2">
-              <h1 className="text-3xl md:text-4xl font-black mb-2">{artist.name}</h1>
-              <p className="text-gray-600 mb-6">{artist.fullName}</p>
-
-              <div className="prose prose-lg max-w-none" dangerouslySetInnerHTML={{ __html: artist.bio }} />
-
-              <div className="mt-8">
-                <h2 className="text-2xl font-bold mb-4">Featured Music</h2>
-
-                <iframe
-                  src={`https://open.spotify.com/embed/artist/${artist.spotifyUrl.split("/").pop()}`}
-                  width="100%"
-                  height="380"
-                  frameBorder="0"
-                  allow="encrypted-media"
-                  className="border-4 border-black"
-                ></iframe>
+              <h1 className="text-3xl md:text-5xl font-black mb-3">{artist.name}</h1>
+              {artist.genre && (
+                <p className="text-sm uppercase tracking-wide text-muted-foreground mb-6">{artist.genre}</p>
+              )}
+              <div className="space-y-6 text-base md:text-lg leading-relaxed text-foreground/90">
+                {description.map((paragraph, index) => (
+                  <p key={`${artist.id}-bio-${index}`}>{paragraph}</p>
+                ))}
               </div>
             </div>
           </div>
-        </div>
+        </article>
       </div>
     </div>
   )

--- a/app/artists/page.tsx
+++ b/app/artists/page.tsx
@@ -1,84 +1,21 @@
 import { getAllArtists } from "@/lib/repositories/content"
-import type { Artist } from "@/lib/types/content"
-import { getAssetUrl } from "@/lib/utils/assets"
+import { notFound } from "next/navigation"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
 import { ChartItem, FeaturedVideoHero, SectionHeader } from "@/components/design-system"
 
-const fallbackArtists = [
-  {
-    _id: "1",
-    name: "Tayc",
-    shortDescription: "French-Cameroonian R&B sensation taking Europe by storm",
-    profileImageUrl: getAssetUrl("images/tayc-2.jpeg"),
-    slug: "tayc",
-    countryCode: "FR",
-    featured: true
-  },
-  {
-    _id: "2",
-    name: "James BKS",
-    shortDescription: "Producer and son of Manu Dibango blending African sounds with hip-hop",
-    profileImageUrl: "https://chartroommedia.com/wp-content/uploads/2023/10/1R3A1242_JAMESBKS_FIFOU.jpg",
-    slug: "james-bks",
-    countryCode: "FR",
-    featured: true
-  },
-  {
-    _id: "3",
-    name: "Yame",
-    shortDescription: "Rising star with a unique blend of Afrobeats and contemporary R&B",
-    profileImageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQZtvYLD7t1tmbgdQ_EVBwAmg3Apx2pnT7sUsYo0tGfW4M8smpyvtxE2hTnh7h1k7V6ZWM&usqp=CAU",
-    slug: "yame",
-    countryCode: "BE",
-    featured: false
-  },
-  {
-    _id: "4",
-    name: "Kang",
-    shortDescription: "Innovative artist pushing the boundaries of Afrobeats with electronic influences",
-    profileImageUrl: getAssetUrl("images/kang_Gang.png"),
-    slug: "kang",
-    countryCode: "CM",
-    featured: false
-  },
-  {
-    _id: "5",
-    name: "Ronid Goliath",
-    shortDescription: "DJ and producer bringing Cameroonian rhythms to dance floors worldwide",
-    profileImageUrl: "https://africanmusiclibrary.org/_next/image?url=https%3A%2F%2Fd31btwpnsku5px.cloudfront.net%2F9e53c72a1e06.jpg&w=3840&q=75",
-    slug: "ronis-goliath",
-    countryCode: "CM",
-    featured: false
-  },
-  {
-    _id: "6",
-    name: "Haira Berylie",
-    shortDescription: "Singer-songwriter known for her vibrant Afrobeat and pop-infused sound",
-    profileImageUrl: getAssetUrl("images/haira_1.jpg"),
-    slug: "haira-berylie",
-    countryCode: "CM",
-    featured: false
-  },
-  {
-    _id: "7",
-    name: "Clerel",
-    shortDescription: "Cameroonian-born soul singer crafting vintage-inspired R&B from his base in Canada.",
-    profileImageUrl: "https://mobile-img.lpcdn.ca/lpca/924x/r3996/e8d4f304-d35a-11ea-b8ad-02fe89184577.jpg",
-    slug: "clerel",
-    countryCode: "CA",
-    featured: false
-  },
-] as any[]
-
 export default async function ArtistsPage() {
-  const rawArtists = await getAllArtists()
-  const artists = rawArtists.length > 0 ? rawArtists : fallbackArtists
+  if (!publicContentVisibility.artists) {
+    notFound()
+  }
+
+  const artists = await getAllArtists()
 
   // Featured Artist (Hero)
-  const featuredArtist = artists.find(a => a.featured) || artists[0]
+  const featuredArtist = artists.find((artist) => artist.featured) || artists[0] || null
 
   // Remaining List
   const listArtists = featuredArtist
-    ? artists.filter(a => a._id !== featuredArtist._id)
+    ? artists.filter((artist) => artist.id !== featuredArtist.id)
     : artists
 
   return (
@@ -103,7 +40,7 @@ export default async function ArtistsPage() {
         <div className="flex flex-col border-t border-border">
           {listArtists.map((artist, index) => (
             <ChartItem
-              key={artist._id}
+              key={artist.id}
               rank={index + 1}
               title={artist.name}
               artist={artist.shortDescription || "Cameroon"}
@@ -113,6 +50,12 @@ export default async function ArtistsPage() {
             />
           ))}
         </div>
+
+        {artists.length === 0 && (
+          <div className="rounded-lg border border-border p-8 text-muted-foreground">
+            No artists are currently published.
+          </div>
+        )}
       </div>
     </div>
   )

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image"
 import Link from "next/link"
-import { Calendar, User, ArrowLeft } from "lucide-react"
-import { getAssetUrl } from "@/lib/utils/assets"
+import { ArrowLeft, Calendar, User } from "lucide-react"
+import { notFound } from "next/navigation"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
+import { getBlogPostBySlug } from "@/lib/repositories/content"
 
 interface BlogPostPageProps {
   params: {
@@ -9,193 +11,86 @@ interface BlogPostPageProps {
   }
 }
 
-export default function BlogPostPage({ params }: BlogPostPageProps) {
-  // In a real app, you would fetch the blog post data based on the slug
-  // For this example, we'll use hardcoded data
+const normalizeContent = (value: unknown): string[] => {
+  if (!value) return []
 
-  const blogPosts = {
-    "tayc-redefining-french-rb": {
-      title: "How Tayc is Redefining French R&B with Cameroonian Influences",
-      date: "April 15, 2025",
-      author: "The Fireside Tribe",
-      imageSrc: getAssetUrl("images/tayc.jpg"),
-      content: `
-        <p class="text-lg mb-4">
-          Tayc, born Julien Bouadjie, has emerged as one of the most exciting voices in French R&B, bringing his Cameroonian heritage to the forefront of his music and creating a unique sound that's captivating audiences across Europe and beyond.
-        </p>
-        
-        <p class="mb-4">
-          Born to Cameroonian parents in Marseille, France, Tayc's music is a beautiful fusion of African rhythms, particularly those from Cameroon, with contemporary R&B and Afrobeats. His smooth vocals, often switching between French and occasional phrases in Cameroonian dialects, have become his signature style.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">The Cameroonian Influence</h2>
-        
-        <p class="mb-4">
-          What sets Tayc apart in the French music scene is his deliberate incorporation of his Cameroonian roots. While many artists with African heritage might dilute these influences to appeal to mainstream European audiences, Tayc embraces them, creating a sound that feels authentic and fresh.
-        </p>
-        
-        <p class="mb-4">
-          His hit single "N'y pense plus" features subtle Bikutsi rhythms, a traditional music style from Cameroon, while "Le temps" incorporates elements of Makossa, another Cameroonian genre made famous by artists like Manu Dibango.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">Breaking Boundaries</h2>
-        
-        <p class="mb-4">
-          Tayc's success represents something significant in the music industry: the growing appreciation for African musical influences in European pop culture. His ability to top French charts while staying true to his Cameroonian roots has opened doors for other artists from the African diaspora.
-        </p>
-        
-        <p class="mb-4">
-          With millions of streams across platforms and sold-out shows throughout France, Tayc is proving that audiences are hungry for authentic cultural expressions in music. His success story is an inspiration for young Cameroonian artists looking to make their mark without compromising their identity.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">What's Next for Tayc</h2>
-        
-        <p class="mb-4">
-          As Tayc's star continues to rise, he's expressed interest in collaborating with more artists from Cameroon and bringing greater attention to the country's rich musical heritage. His platform is increasingly becoming a bridge between European and African music scenes.
-        </p>
-        
-        <p class="mb-4">
-          For fans of Cameroonian music, Tayc represents an exciting ambassador who's introducing the sounds of Cameroon to new audiences while creating something fresh and innovative in the process.
-        </p>
-      `,
-    },
-    "james-bks-legacy": {
-      title: "The Legacy of Manu Dibango Through James BKS",
-      date: "March 28, 2025",
-      author: "The Fireside Tribe",
-      imageSrc: getAssetUrl("images/james-bks.jpg"),
-      content: `
-        <p class="text-lg mb-4">
-          When legendary Cameroonian saxophonist and composer Manu Dibango passed away in 2020, many wondered who would carry forward his musical legacy. The answer was already making waves in the music industry: his son, James BKS.
-        </p>
-        
-        <p class="mb-4">
-          Born James Edjouma, James BKS has forged his own path in music while honoring his father's groundbreaking contributions. As a producer who has worked with the likes of Diddy, Talib Kweli, and French rapper Booba, James brings a contemporary sensibility to the Afro-jazz foundations laid by his father.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">A Unique Musical Journey</h2>
-        
-        <p class="mb-4">
-          What makes James BKS's story particularly interesting is that he didn't grow up with Dibango. Raised in France by his mother and adoptive father, James only connected with Manu Dibango as an adult, after already establishing himself in the music industry.
-        </p>
-        
-        <p class="mb-4">
-          This reunion with his biological father sparked a musical rebirth for James. While he had been successful producing hip-hop in the United States, reconnecting with Dibango inspired him to explore his Cameroonian roots and incorporate African sounds into his production.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">Bridging Worlds</h2>
-        
-        <p class="mb-4">
-          James BKS's music serves as a bridge between generations and genres. His track "Kwele," featuring Dibango himself alongside Allan Kingdom and Manu's longtime collaborator Marthe, perfectly exemplifies this fusion of traditional Cameroonian elements with contemporary production techniques.
-        </p>
-        
-        <p class="mb-4">
-          Through his label Grown Kid Records, he's also helping to promote other Cameroonian electronic artists to global audiences.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">Preserving and Innovating</h2>
-        
-        <p class="mb-4">
-          Since Dibango's passing, James has taken on the dual responsibility of preserving his father's musical legacy while continuing to innovate. His approach isn't to simply mimic Dibango's style but to build upon it, bringing those sounds to new audiences through contemporary contexts.
-        </p>
-        
-        <p class="mb-4">
-          For Cameroonian music fans, James BKS represents an exciting continuation of Manu Dibango's work in breaking down musical boundaries and showcasing Cameroonian sounds on the global stage. His story is a powerful reminder of how musical legacies can evolve and find new expressions across generations.
-        </p>
-      `,
-    },
-    "cameroonian-artists-global": {
-      title: "5 Cameroonian Artists Making Waves Internationally",
-      date: "March 10, 2025",
-      author: "The Fireside Tribe",
-      imageSrc: getAssetUrl("images/kang.jpg"),
-      content: `
-        <p class="text-lg mb-4">
-          Cameroon has long been a hotbed of musical talent, but in recent years, a new generation of artists has been breaking through on the international scene. From innovative producers to soulful vocalists, these artists are putting Cameroon on the global music map while staying true to their roots.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">1. Kang</h2>
-        
-        <p class="mb-4">
-          With his distinctive voice and genre-blending approach, Kang has emerged as one of Cameroon's most exciting musical exports. Blending Afrobeats with elements of R&B and traditional Cameroonian sounds, Kang has cultivated a growing international fanbase. His breakthrough single "Mbelek" showcased his ability to create infectious rhythms while incorporating lyrics in both French and his native dialect.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">2. Yame</h2>
-        
-        <p class="mb-4">
-          Yame has been steadily building a reputation for soulful vocals and thoughtful songwriting. Based between Paris and Douala, her music explores themes of identity and belonging, resonating with the Cameroonian diaspora worldwide. Her EP "Roots & Wings" received critical acclaim for its authentic blend of contemporary R&B with subtle nods to Bikutsi rhythms.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">3. Ronis Goliath</h2>
-        
-        <p class="mb-4">
-          As a producer and DJ, Ronis Goliath has become an influential figure in electronic music circles. His innovative approach to incorporating Cameroonian samples and rhythms into house and electronic productions has earned him slots at major festivals across Europe. Through his label Tribal Connection, he's also helping to promote other Cameroonian electronic artists to global audiences.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">4. James BKS</h2>
-        
-        <p class="mb-4">
-          The son of legendary Manu Dibango, James BKS has forged his own path while honoring his father's legacy. After successful stints producing for American hip-hop artists, James returned to his roots, creating a unique sound that bridges African rhythms with contemporary production techniques. His collaboration with Idris Elba and Little Simz on "Kwele" showcased his ability to bring Cameroonian sounds to new audiences.
-        </p>
-        
-        <h2 class="text-2xl font-bold mt-8 mb-4">5. Tayc</h2>
-        
-        <p class="mb-4">
-          Though based in France, Tayc's Cameroonian heritage shines through in his music. His smooth R&B vocals and incorporation of Afrobeats elements have made him a star in the Francophone music world and beyond. With millions of streams and a growing international presence, Tayc represents the new wave of Cameroonian-influenced artists making their mark globally.
-        </p>
-        
-        <p class="mb-4">
-          These artists represent just a small sample of the incredible talent emerging from Cameroon and its diaspora. As global interest in African music continues to grow, these innovative musicians are ensuring that Cameroon's rich musical heritage evolves and reaches new audiences worldwide.
-        </p>
-      `,
-    },
+  if (typeof value === "string") {
+    return value
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean)
   }
 
-  const post = blogPosts[params.slug]
-
-  if (!post) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold mb-4">Blog Post Not Found</h1>
-          <Link href="/blog" className="text-blue-600 hover:underline">
-            Back to Blog
-          </Link>
-        </div>
-      </div>
-    )
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => normalizeContent(item))
   }
+
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap((item) => normalizeContent(item))
+  }
+
+  return []
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  if (!publicContentVisibility.blog) {
+    notFound()
+  }
+
+  const post = await getBlogPostBySlug(params.slug)
+  if (!post || !post.published) {
+    notFound()
+  }
+
+  const paragraphs = normalizeContent(post.content)
+  const articleBody = paragraphs.length > 0 ? paragraphs : [post.excerpt].filter(Boolean)
 
   return (
-    <div className="min-h-screen bg-yellow-50 py-12 px-4">
+    <div className="min-h-screen bg-background py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <Link
           href="/blog"
-          className="inline-flex items-center gap-2 mb-8 font-bold hover:text-red-500 transition-colors"
+          className="inline-flex items-center gap-2 mb-8 text-sm uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
         >
-          <ArrowLeft size={20} />
-          Back to Blog
+          <ArrowLeft size={16} />
+          Back to Editorial
         </Link>
 
-        <article className="bg-white border-4 border-black p-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
-          <h1 className="text-3xl md:text-4xl font-black mb-4">{post.title}</h1>
+        <article className="bg-card border border-border p-8 md:p-12 rounded-lg">
+          <h1 className="text-3xl md:text-5xl font-black mb-6">{post.title}</h1>
 
-          <div className="flex items-center gap-4 mb-6 text-gray-600">
-            <div className="flex items-center gap-1">
-              <Calendar size={16} />
-              <span>{post.date}</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <User size={16} />
-              <span>{post.author}</span>
-            </div>
+          <div className="flex flex-wrap items-center gap-6 mb-8 text-sm text-muted-foreground">
+            {post.publishedAt && (
+              <div className="flex items-center gap-2">
+                <Calendar size={16} />
+                <span>{post.publishedAt}</span>
+              </div>
+            )}
+            {post.author && (
+              <div className="flex items-center gap-2">
+                <User size={16} />
+                <span>{post.author}</span>
+              </div>
+            )}
           </div>
 
-          <div className="relative h-[300px] md:h-[400px] mb-8 border-4 border-black">
-            <Image src={post.imageSrc || "/placeholder.svg"} alt={post.title} fill className="object-cover" />
-          </div>
+          {post.featuredImageUrl && (
+            <div className="relative h-[280px] md:h-[420px] mb-10 overflow-hidden rounded-md border border-border">
+              <Image
+                src={post.featuredImageUrl}
+                alt={post.featuredImageAlt || post.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 896px"
+              />
+            </div>
+          )}
 
-          <div className="prose prose-lg max-w-none" dangerouslySetInnerHTML={{ __html: post.content }} />
+          <div className="space-y-6 text-base md:text-lg leading-relaxed text-foreground/90">
+            {articleBody.map((paragraph, index) => (
+              <p key={`${post.id}-paragraph-${index}`}>{paragraph}</p>
+            ))}
+          </div>
         </article>
       </div>
     </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,82 +1,18 @@
 import { getAllBlogPosts } from "@/lib/repositories/content"
-import type { BlogPost } from "@/lib/types/content"
-import { getAssetUrl } from "@/lib/utils/assets"
+import { notFound } from "next/navigation"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
 import { EditorialCard, SectionHeader } from "@/components/design-system"
 
-const fallbackPosts = [
-  {
-    _id: "1",
-    title: "How Tayc is Redefining French R&B with Cameroonian Influences",
-    excerpt: "Explore how Tayc's Cameroonian heritage shapes his unique sound and international appeal.",
-    publishedAt: "April 15, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: "https://resources.tidal.com/images/f084332e/e75d/4448/9314/034a7950668a/750x750.jpg",
-    slug: "tayc-redefining-french-rb",
-    featured: true
-  },
-  {
-    _id: "2",
-    title: "The Legacy of Manu Dibango Through James BKS",
-    excerpt: "How James BKS is carrying forward his father's musical legacy while creating his own path.",
-    publishedAt: "March 28, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: "https://i.scdn.co/image/ab6761610000e5ebefcb83d283a993edd482360d",
-    slug: "james-bks-legacy",
-    featured: false
-  },
-  {
-    _id: "3",
-    title: "5 Cameroonian Artists Making Waves Internationally",
-    excerpt: "From Kang to Ronis Goliath, these artists are putting Cameroon on the global music map.",
-    publishedAt: "March 10, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: getAssetUrl("images/kang_Gang.png"),
-    slug: "cameroonian-artists-global",
-    featured: false
-  },
-  {
-    _id: "4",
-    title: "The Evolution of Bikutsi: From Traditional to Contemporary",
-    excerpt: "Tracing the journey of one of Cameroon's most distinctive musical styles through the decades.",
-    publishedAt: "February 20, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: getAssetUrl("images/reniss-afrocharts.jpg"),
-    slug: "evolution-of-bikutsi",
-    featured: false
-  },
-  {
-    _id: "5",
-    title: "Douala's Rising Music Scene: Studios and Producers to Watch",
-    excerpt: "Behind the artists are innovative studios and producers creating the soundtrack of modern Cameroon.",
-    publishedAt: "February 5, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: getAssetUrl("images/ber_boys.jpg"),
-    slug: "douala-music-scene",
-    featured: false
-  },
-  {
-    _id: "6",
-    title: "From Cameroon to the World: The Diaspora Effect on Music",
-    excerpt: "How Cameroonian artists abroad are influencing global sounds while staying connected to their roots.",
-    publishedAt: "January 18, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: getAssetUrl("images/ko-c.webp"),
-    slug: "cameroon-diaspora-music",
-    featured: false
-  },
-] as any[]
-
 export default async function BlogPage() {
-  const rawPosts = await getAllBlogPosts()
-  const posts = rawPosts.length > 0 ? rawPosts : fallbackPosts
+  if (!publicContentVisibility.blog) {
+    notFound()
+  }
 
-  // Strategy: 
-  // 1. Featured Article (First featured or first item)
-  // 2. Sub-Featured Grid (Next 2 items)
-  // 3. The Rest (List view)
-
-  const featuredPost = posts.find(p => p.featured) || posts[0]
-  const remainingPosts = posts.filter(p => p._id !== featuredPost._id)
+  const posts = await getAllBlogPosts()
+  const featuredPost = posts.find((post) => post.featured) || posts[0] || null
+  const remainingPosts = featuredPost
+    ? posts.filter((post) => post.id !== featuredPost.id)
+    : []
 
   const subFeatured = remainingPosts.slice(0, 2)
   const listPosts = remainingPosts.slice(2)
@@ -94,7 +30,7 @@ export default async function BlogPage() {
         </div>
 
         {/* Featured Section */}
-        {featuredPost && (
+        {featuredPost ? (
           <section className="mb-16">
             <EditorialCard
               title={featuredPost.title}
@@ -107,6 +43,10 @@ export default async function BlogPage() {
               variant="featured"
             />
           </section>
+        ) : (
+          <section className="mb-16 rounded-lg border border-border p-8 text-muted-foreground">
+            No editorial posts are currently published.
+          </section>
         )}
 
         {/* Sub-Featured Grid */}
@@ -114,7 +54,7 @@ export default async function BlogPage() {
           <section className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16 border-b border-border pb-16">
             {subFeatured.map(post => (
               <EditorialCard
-                key={post._id}
+                key={post.id}
                 title={post.title}
                 excerpt={post.excerpt}
                 imageUrl={post.featuredImageUrl || '/placeholder.svg'}
@@ -133,7 +73,7 @@ export default async function BlogPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {listPosts.map(post => (
                 <EditorialCard
-                  key={post._id}
+                  key={post.id}
                   title={post.title}
                   author={post.author}
                   imageUrl={post.featuredImageUrl || '/placeholder.svg'}

--- a/app/episodes/page.tsx
+++ b/app/episodes/page.tsx
@@ -1,48 +1,8 @@
 import { getAllEpisodes } from "@/lib/repositories/content"
-import type { Episode } from "@/lib/types/content"
-import { getAssetUrl } from "@/lib/utils/assets"
 import { FeaturedVideoHero, VideoCard, SectionHeader } from "@/components/design-system"
 
-// Fallback data for development if no episodes exist
-const fallbackEpisodes = [
-  {
-    id: "1",
-    title: "The Rise of Cameroonian Artists Globally",
-    description: "Discover how Cameroonian artists are making waves on the international music scene.",
-    publishedAt: "March 15, 2025",
-    spotifyUrl: "https://open.spotify.com/episode/4MLpsIqPq6fdhAsDfN5lP5",
-    youtubeUrl: "https://youtu.be/mw4xLb59QO0",
-    coverImageUrl: getAssetUrl("images/sepo.jpg"),
-    slug: "rise-of-cameroonian-artists",
-    featured: true
-  },
-  {
-    id: "2",
-    title: "Exploring Cameroon's Afrobeats Scene",
-    description: "Dive into the rich sounds and rhythms of Cameroon's growing Afrobeats movement.",
-    publishedAt: "April 20, 2025",
-    spotifyUrl: "https://open.spotify.com/episode/4qxmv4JdlfIwJM0nUFOhCJ",
-    youtubeUrl: "https://youtu.be/kD-wI-jZQBY",
-    coverImageUrl: getAssetUrl("images/jail_time_records_cover.png"),
-    slug: "exploring-cameroon-afrobeats",
-    featured: false
-  },
-  {
-    id: "3",
-    title: "Spotlight on Douala's Music Scene",
-    description: "Exploring the vibrant underground music culture in Cameroon's largest city.",
-    publishedAt: "May 5, 2025",
-    spotifyUrl: "https://open.spotify.com/episode/4MLpsIqPq6fdhAsDfN5lP5",
-    youtubeUrl: "https://youtu.be/mw4xLb59QO0",
-    coverImageUrl: getAssetUrl("images/ber_boys.jpg"),
-    slug: "douala-music-scene",
-    featured: false
-  },
-] as any[]
-
 export default async function EpisodesPage() {
-  const rawEpisodes = await getAllEpisodes()
-  const episodes = rawEpisodes.length > 0 ? rawEpisodes : fallbackEpisodes
+  const episodes = await getAllEpisodes()
 
   // Strategy: Find first featured episode, or default to first episode
   const featuredEpisode = episodes.find((e) => e.featured) || episodes[0] || null
@@ -82,7 +42,7 @@ export default async function EpisodesPage() {
             />
           ))}
 
-          {/* If simplified fallback logic resulted in duplicates or empty, ensure we show the rest */}
+          {/* Empty state when no episodes are currently available */}
           {(!featuredEpisode && otherEpisodes.length === 0) && (
             <div className="col-span-full text-center text-gray-500 py-20">
               No episodes found.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { AnalyticsProvider } from "@/components/posthog-provider"
 import { Header } from "@/components/layout/Header"
 import { Footer } from "@/components/layout/Footer"
 import { isContentLive } from "@/lib/config/publishing"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
 import { getAAAPagePublishingWindow } from "@/lib/repositories/pages"
 import { ConvexClientProvider } from "@/components/providers/ConvexClientProvider"
 
@@ -46,6 +47,7 @@ export default async function RootLayout({
 
   const publishWindow = await getAAAPagePublishingWindow()
   const showAAAPage = isContentLive(publishWindow)
+  const { artists: showArtistsPage, blog: showBlogPage } = publicContentVisibility
 
   return (
     <ClerkProvider>
@@ -65,14 +67,19 @@ export default async function RootLayout({
             <AnalyticsProvider>
               <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
                 {/* Billboard-Style Header */}
-                <Header logoUrl={logoUrl} showAAAPage={showAAAPage} />
+                <Header
+                  logoUrl={logoUrl}
+                  showAAAPage={showAAAPage}
+                  showArtistsPage={showArtistsPage}
+                  showBlogPage={showBlogPage}
+                />
 
                 {/* Main Content - Add top padding for fixed header */}
                 <main className="pt-16 min-h-screen">
                   {children}
                 </main>
 
-                <Footer logoUrl={logoUrl} />
+                <Footer logoUrl={logoUrl} showArtistsPage={showArtistsPage} showBlogPage={showBlogPage} />
               </ThemeProvider>
             </AnalyticsProvider>
           </ConvexClientProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,7 @@
-import Link from "next/link"
-import { ArrowRight } from "lucide-react"
-
 import { getFeaturedArtists, getLatestEpisodes, getLatestBlogPosts } from "@/lib/repositories/content"
-import type { Artist, BlogPost, Episode } from "@/lib/types/content"
-import { getAssetUrl } from "@/lib/utils/assets"
+import { publicContentVisibility } from "@/lib/config/content-visibility"
 import {
-  FeaturedVideoHero,
+  MultiPlatformHero,
   VideoCard,
   EditorialCard,
   ChartItem,
@@ -15,218 +11,141 @@ import { ArtistCircle } from "@/components/design-system/ArtistCircle"
 
 export const revalidate = 0 // Force dynamic rendering
 
-// --- FALLBACK DATA ---
-const fallbackEpisodes = [
-  {
-    id: "1",
-    title: "Exploring Cameroon's Afrobeats Scene",
-    description: "Dive into the rich sounds and rhythms of Cameroon's growing Afrobeats movement.",
-    publishedAt: "April 20, 2025",
-    spotifyUrl: "https://open.spotify.com/episode/4qxmv4JdlfIwJM0nUFOhCJ",
-    youtubeUrl: "https://youtu.be/kD-wI-jZQBY",
-    coverImageUrl: getAssetUrl("images/jovi3.png"),
-    slug: "exploring-cameroons-afrobeats-scene",
-  },
-  {
-    id: "2",
-    title: "The Rise of Cameroonian Artists Globally",
-    description: "Discover how Cameroonian artists are making waves on the international music scene.",
-    publishedAt: "March 15, 2025",
-    spotifyUrl: "https://open.spotify.com/episode/4MLpsIqPq6fdhAsDfN5lP5",
-    youtubeUrl: "https://youtu.be/mw4xLb59QO0",
-    coverImageUrl: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.byPUWkyhJy3cnZmiGVzu8QHaHb%26pid%3DApi&f=1",
-    slug: "the-rise-of-cameroonian-artists-globally",
-  },
-] as any[]
-
-const fallbackArtists = [
-  {
-    id: "1",
-    name: "Lebianca",
-    shortDescription: "Rising Cameroonian star known for soulful Afrobeats and R&B.",
-    profileImageUrl: "https://i.ytimg.com/vi/wBRe8D-PKOs/maxresdefault.jpg",
-    slug: "lebianca",
-    orderRank: 1,
-  },
-  {
-    id: "2",
-    name: "Kocee",
-    shortDescription: "Cameroonian Afrobeats artist with infectious rhythms.",
-    profileImageUrl: "https://i.ytimg.com/vi/wBRe8D-PKOs/maxresdefault.jpg",
-    slug: "kocee",
-    orderRank: 2,
-  },
-  {
-    id: "3",
-    name: "Jovi",
-    shortDescription: "Le Monstre - Pioneering Cameroonian rapper and producer.",
-    profileImageUrl: getAssetUrl("images/jovi3.png"),
-    slug: "jovi",
-    orderRank: 3,
-  },
-  {
-    id: "4",
-    name: "DJ Bizi Brown",
-    shortDescription: "Legendary Cameroonian DJ and music curator.",
-    profileImageUrl: "/placeholder.svg",
-    slug: "dj-bizi-brown",
-    orderRank: 4,
-  },
-  {
-    id: "5",
-    name: "Yame",
-    shortDescription: "Cameroonian artist blending traditional and modern sounds.",
-    profileImageUrl: "https://i.ytimg.com/vi/lukT_WB5IB0/maxresdefault.jpg",
-    slug: "yame",
-    orderRank: 5,
-  },
-] as any[]
-
-const fallbackPosts = [
-  {
-    id: "1",
-    title: "How Tayc is Redefining French R&B with Cameroonian Influences",
-    excerpt: "Explore how Tayc's Cameroonian heritage shapes his unique sound and international appeal.",
-    publishedAt: "April 15, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: "https://resources.tidal.com/images/d49938db/8882/4b34/86ba/9811e589222b/640x640.jpg",
-    slug: "tayc-redefining-french-rb",
-  },
-  {
-    id: "2",
-    title: "The Legacy of Manu Dibango Through James BKS",
-    excerpt: "How James BKS is carrying forward his father's musical legacy while creating his own path.",
-    publishedAt: "March 28, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: "https://pan-african-music.com/wp-content/uploads/2019/11/37eed9ff-james-bks.jpg",
-    slug: "james-bks-legacy",
-  },
-  {
-    id: "3",
-    title: "5 Cameroonian Artists Making Waves Internationally",
-    excerpt: "From Kang to Ronis Goliath, these artists are putting Cameroon on the global music map.",
-    publishedAt: "March 10, 2025",
-    author: "The Fireside Tribe",
-    featuredImageUrl: "https://static.wixstatic.com/media/5e0aaf_4333086aaa1f43d88a26581b7dc5e2fc~mv2.jpg/v1/fill/w_640,h_640,al_c,q_85,usm_2.00_1.00_0.00,enc_avif,quality_auto/Image-empty-state_edited_edited.jpg",
-    slug: "cameroonian-artists-global",
-  },
-] as any[]
-
 export default async function Home() {
-  // Fetch real data parallely
-  const [episodesRaw, artistsRaw, postsRaw] = await Promise.all([
+  const { artists: showArtists, blog: showBlog } = publicContentVisibility
+
+  const [episodes, artists, posts] = await Promise.all([
     getLatestEpisodes(4),
-    getFeaturedArtists(5),
-    getLatestBlogPosts(3),
+    showArtists ? getFeaturedArtists(5) : Promise.resolve([]),
+    showBlog ? getLatestBlogPosts(3) : Promise.resolve([]),
   ])
 
-  // Use fallbacks if empty
-  const episodes = episodesRaw.length > 0 ? episodesRaw : fallbackEpisodes
-  const artists = artistsRaw.length > 0 ? artistsRaw : fallbackArtists
-  const posts = postsRaw.length > 0 ? postsRaw : fallbackPosts
+  // TikTok and YouTube video IDs for multi-platform hero
+  const tiktokVideoIds = [
+    "7537815820701879608",
+    "7588315471515110664",
+    "7584791817955183879",
+    "7571594930435476744",
+  ]
 
-  const featuredEpisode = episodes[0]
-  const recentEpisodes = episodes.slice(1)
+  const youtubeVideoIds = [
+    "ieUD7NY_WxU",
+    "4rTi2TUzWTI",
+    "eath6AJfh3Y",
+    "ndoTJ0ApWU4",
+  ]
 
   return (
     <div className="min-h-screen bg-background text-foreground pb-24">
 
-      {/* 1. HERO SECTION (Featured Episode) */}
-      {featuredEpisode && (
-        <FeaturedVideoHero
-          title={featuredEpisode.title}
-          description={featuredEpisode.description}
-          subtitle="New Episode Out Now"
-          thumbnailUrl="/images/hero-banner.jpg"
-          href={`/episodes/${featuredEpisode.slug}`}
-          label="Latest Release"
-          className="aspect-[4/5] md:aspect-[21/9]"
-        />
-      )}
+      {/* 1. HERO SECTION (Multi-Platform Showcase) */}
+      <MultiPlatformHero
+        tiktokVideoIds={tiktokVideoIds}
+        youtubeVideoIds={youtubeVideoIds}
+        instagramUsername="thefiresidetribe"
+        autoPlayInterval={10000}
+      />
 
       <div className="container mx-auto px-4 space-y-20 mt-12">
+        {showArtists && artists.length > 0 && (
+          <>
+            {/* 2. TRENDING ARTISTS (Horizontal Scroll) */}
+            <section>
+              <SectionHeader title="Trending Artists" href="/artists" linkText="All Artists" />
+              <div className="flex overflow-x-auto pb-6 gap-6 scrollbar-hide snap-x">
+                {artists.map((artist) => (
+                  <ArtistCircle
+                    key={artist.id}
+                    name={artist.name}
+                    imageUrl={artist.profileImageUrl || "/placeholder.svg"}
+                    href={`/artists/${artist.slug}`}
+                  />
+                ))}
+              </div>
+            </section>
 
-        {/* 2. TRENDING ARTISTS (Horizontal Scroll) */}
-        <section>
-          <SectionHeader title="Trending Artists" href="/artists" linkText="All Artists" />
-          <div className="flex overflow-x-auto pb-6 gap-6 scrollbar-hide snap-x">
-            {artists.map(artist => (
-              <ArtistCircle
-                key={artist.id}
-                name={artist.name}
-                imageUrl={artist.profileImageUrl || '/placeholder.svg'}
-                href={`/artists/${artist.slug}`}
-              />
-            ))}
-          </div>
-        </section>
+            {/* 3. CHART TOPPERS (List Style) */}
+            <section className="grid grid-cols-1 lg:grid-cols-12 gap-12">
+              <div className="col-span-1 lg:col-span-8">
+                <SectionHeader title="Fireside Charts" href="/artists" linkText="Full Chart" />
+                <div className="flex flex-col">
+                  {artists.slice(0, 5).map((artist, index) => (
+                    <ChartItem
+                      key={artist.id}
+                      rank={index + 1}
+                      title={artist.name}
+                      artist={artist.shortDescription || "Cameroon"}
+                      coverUrl={artist.profileImageUrl || "/placeholder.svg"}
+                      href={`/artists/${artist.slug}`}
+                      trend={index === 0 ? "same" : index === 1 ? "up" : "down"}
+                      lastWeek={index + 2}
+                    />
+                  ))}
+                </div>
+              </div>
 
-        {/* 3. CHART TOPPERS (List Style) */}
-        <section className="grid grid-cols-1 lg:grid-cols-12 gap-12">
-          <div className="col-span-1 lg:col-span-8">
-            <SectionHeader title="Fireside Charts" href="/artists" linkText="Full Chart" />
-            <div className="flex flex-col">
-              {artists.slice(0, 5).map((artist: any, index: number) => (
-                <ChartItem
-                  key={artist.id}
-                  rank={index + 1}
-                  title={artist.name}
-                  artist={artist.shortDescription || "Cameroon"}
-                  coverUrl={artist.profileImageUrl || '/placeholder.svg'}
-                  href={`/artists/${artist.slug}`}
-                  trend={index === 0 ? "same" : index === 1 ? "up" : "down"}
-                  lastWeek={index + 2}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Sidebar: Newsletter or Ad space */}
-          <div className="col-span-1 lg:col-span-4 hidden lg:block">
-            <div className="bg-secondary/50 p-8 h-full flex flex-col justify-center text-center border border-border">
-              <h3 className="font-heading font-bold text-2xl uppercase mb-4">Join The Tribe</h3>
-              <p className="text-muted-foreground mb-6 text-sm">Get the weekly chart rundown and exclusive artist interviews.</p>
-              <input type="email" placeholder="Email Address" className="w-full bg-background border border-border p-3 text-foreground mb-3 text-sm focus:border-primary outline-none" />
-              <button className="w-full bg-primary text-primary-foreground font-bold uppercase py-3 text-sm hover:bg-foreground hover:text-background transition-colors">Subscribe</button>
-            </div>
-          </div>
-        </section>
+              {/* Sidebar: Newsletter or Ad space */}
+              <div className="col-span-1 lg:col-span-4 hidden lg:block">
+                <div className="bg-secondary/50 p-8 h-full flex flex-col justify-center text-center border border-border">
+                  <h3 className="font-heading font-bold text-2xl uppercase mb-4">Join The Tribe</h3>
+                  <p className="text-muted-foreground mb-6 text-sm">
+                    Get the weekly chart rundown and exclusive artist interviews.
+                  </p>
+                  <input
+                    type="email"
+                    placeholder="Email Address"
+                    className="w-full bg-background border border-border p-3 text-foreground mb-3 text-sm focus:border-primary outline-none"
+                  />
+                  <button className="w-full bg-primary text-primary-foreground font-bold uppercase py-3 text-sm hover:bg-foreground hover:text-background transition-colors">
+                    Subscribe
+                  </button>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
 
         {/* 4. LATEST EPISODES (Grid) */}
         <section>
           <SectionHeader title="Latest Episodes" href="/episodes" />
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {recentEpisodes.map(episode => (
-              <VideoCard
-                key={episode.id}
-                title={episode.title}
-                thumbnailUrl={episode.coverImageUrl || '/placeholder.svg'}
-                href={`/episodes/${episode.slug}`}
-                category="Podcast"
-              />
-            ))}
-          </div>
+          {episodes.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {episodes.map((episode) => (
+                <VideoCard
+                  key={episode.id}
+                  title={episode.title}
+                  thumbnailUrl={episode.coverImageUrl || "/placeholder.svg"}
+                  href={`/episodes/${episode.slug}`}
+                  category="Podcast"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border p-8 text-sm text-muted-foreground">
+              No episodes are published yet.
+            </div>
+          )}
         </section>
 
-        {/* 5. EDITORIAL (Blog) */}
-        <section>
-          <SectionHeader title="Editorial" href="/blog" linkText="Read More" />
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {posts.map((post, idx) => (
-              <EditorialCard
-                key={post.id}
-                title={post.title}
-                excerpt={idx === 0 ? post.excerpt : undefined} // Only show excerpt for first
-                date={post.publishedAt}
-                imageUrl={post.featuredImageUrl || '/placeholder.svg'}
-                href={`/blog/${post.slug}`}
-                category="News"
-                variant="standard"
-              />
-            ))}
-          </div>
-        </section>
-
+        {showBlog && posts.length > 0 && (
+          <section>
+            <SectionHeader title="Editorial" href="/blog" linkText="Read More" />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {posts.map((post, idx) => (
+                <EditorialCard
+                  key={post.id}
+                  title={post.title}
+                  excerpt={idx === 0 ? post.excerpt : undefined}
+                  date={post.publishedAt}
+                  imageUrl={post.featuredImageUrl || "/placeholder.svg"}
+                  href={`/blog/${post.slug}`}
+                  category="News"
+                  variant="standard"
+                />
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </div>
   )

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,13 +1,28 @@
 "use client"
 
 import Link from "next/link"
-import { Facebook, Instagram, Youtube, Twitter } from "lucide-react"
+import { Youtube, Instagram } from "lucide-react"
+
+// TikTok icon component
+function TikTokIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
+    </svg>
+  )
+}
 
 interface FooterProps {
   logoUrl: string
+  showArtistsPage?: boolean
+  showBlogPage?: boolean
 }
 
-export function Footer({ logoUrl }: FooterProps) {
+export function Footer({
+  logoUrl,
+  showArtistsPage = true,
+  showBlogPage = true
+}: FooterProps) {
   return (
     <footer className="bg-background border-t border-border">
       {/* Main Footer Content */}
@@ -33,10 +48,9 @@ export function Footer({ logoUrl }: FooterProps) {
                 Follow Us
               </h3>
               <div className="flex items-center gap-3">
-                <SocialIcon href="https://facebook.com" icon={<Facebook className="w-5 h-5" />} />
-                <SocialIcon href="https://instagram.com" icon={<Instagram className="w-5 h-5" />} />
-                <SocialIcon href="https://twitter.com" icon={<Twitter className="w-5 h-5" />} />
-                <SocialIcon href="https://youtube.com" icon={<Youtube className="w-5 h-5" />} />
+                <SocialIcon href="https://youtube.com/@TheFiresideTribe" icon={<Youtube className="w-5 h-5" />} />
+                <SocialIcon href="https://www.instagram.com/thefiresidetribe/" icon={<Instagram className="w-5 h-5" />} />
+                <SocialIcon href="https://www.tiktok.com/@thefiresidetribe1" icon={<TikTokIcon className="w-5 h-5" />} />
               </div>
             </div>
 
@@ -109,9 +123,13 @@ export function Footer({ logoUrl }: FooterProps) {
               </h4>
               <nav className="flex flex-col gap-3">
                 <FooterLink href="/episodes">Episodes</FooterLink>
-                <FooterLink href="/artists">Artists</FooterLink>
-                <FooterLink href="/blog">Blog</FooterLink>
-                <FooterLink href="/charts">Charts</FooterLink>
+                {showArtistsPage && (
+                  <>
+                    <FooterLink href="/artists">Artists</FooterLink>
+                    <FooterLink href="/charts">Charts</FooterLink>
+                  </>
+                )}
+                {showBlogPage && <FooterLink href="/blog">Blog</FooterLink>}
               </nav>
             </div>
 
@@ -133,9 +151,8 @@ export function Footer({ logoUrl }: FooterProps) {
                 Listen
               </h4>
               <nav className="flex flex-col gap-3">
-                <FooterLink href="https://open.spotify.com" external>Spotify</FooterLink>
-                <FooterLink href="https://music.apple.com" external>Apple Podcasts</FooterLink>
-                <FooterLink href="https://youtube.com" external>YouTube</FooterLink>
+                <FooterLink href="https://open.spotify.com/show/4Pmd0zCt4r1UCEI2mTJdtl" external>Spotify</FooterLink>
+                <FooterLink href="https://youtube.com/@TheFiresideTribe" external>YouTube</FooterLink>
               </nav>
             </div>
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,16 +10,22 @@ import { AdminNavIcon } from "@/components/AdminNavIcon"
 interface HeaderProps {
   logoUrl: string
   showAAAPage?: boolean
+  showArtistsPage?: boolean
+  showBlogPage?: boolean
 }
 
-const navLinks = [
-  { label: "Episodes", href: "/episodes" },
-  { label: "Artists", href: "/artists" },
-  { label: "Blog", href: "/blog" },
-]
-
-export function Header({ logoUrl, showAAAPage }: HeaderProps) {
+export function Header({
+  logoUrl,
+  showAAAPage,
+  showArtistsPage = true,
+  showBlogPage = true
+}: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false)
+  const navLinks = [
+    { label: "Episodes", href: "/episodes" },
+    ...(showArtistsPage ? [{ label: "Artists", href: "/artists" }] : []),
+    ...(showBlogPage ? [{ label: "Blog", href: "/blog" }] : []),
+  ]
 
   return (
     <>
@@ -86,7 +92,13 @@ export function Header({ logoUrl, showAAAPage }: HeaderProps) {
       </header>
 
       {/* Mega Menu Overlay */}
-      <MegaMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} showAAAPage={showAAAPage} />
+      <MegaMenu
+        isOpen={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        showAAAPage={showAAAPage}
+        showArtistsPage={showArtistsPage}
+        showBlogPage={showBlogPage}
+      />
     </>
   )
 }

--- a/components/layout/MegaMenu.tsx
+++ b/components/layout/MegaMenu.tsx
@@ -10,6 +10,8 @@ interface MegaMenuProps {
   isOpen: boolean
   onClose: () => void
   showAAAPage?: boolean
+  showArtistsPage?: boolean
+  showBlogPage?: boolean
 }
 
 const episodeLinks: MenuLink[] = [
@@ -34,10 +36,28 @@ const aboutLinks: MenuLink[] = [
   { label: "Contact", href: "/contact" },
 ]
 
-export function MegaMenu({ isOpen, onClose, showAAAPage }: MegaMenuProps) {
+export function MegaMenu({
+  isOpen,
+  onClose,
+  showAAAPage,
+  showArtistsPage = true,
+  showBlogPage = true
+}: MegaMenuProps) {
   const handleLinkClick = () => {
     onClose()
   }
+
+  const sections = [
+    { title: "EPISODES", links: episodeLinks },
+    ...(showArtistsPage ? [{ title: "ARTISTS", links: artistLinks }] : []),
+    ...(showBlogPage ? [{ title: "BLOG", links: blogLinks }] : []),
+    {
+      title: "ABOUT",
+      links: showAAAPage ? [...aboutLinks, { label: "A³ Initiative", href: "/AAA" }] : aboutLinks
+    },
+  ]
+  const desktopGridClass =
+    sections.length >= 4 ? "md:grid-cols-4" : sections.length === 3 ? "md:grid-cols-3" : "md:grid-cols-2"
 
   return (
     <AnimatePresence>
@@ -69,7 +89,7 @@ export function MegaMenu({ isOpen, onClose, showAAAPage }: MegaMenuProps) {
                 </Link>
 
                 <div className="flex-1 max-w-xl mx-4 hidden md:block">
-                  <SearchInput placeholder="Search episodes, artists, blog..." />
+                  <SearchInput placeholder="Search content..." />
                 </div>
 
                 <button
@@ -87,15 +107,15 @@ export function MegaMenu({ isOpen, onClose, showAAAPage }: MegaMenuProps) {
               </div>
 
               {/* Category Grid */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12">
-                <MenuSection title="EPISODES" links={episodeLinks} onLinkClick={handleLinkClick} />
-                <MenuSection title="ARTISTS" links={artistLinks} onLinkClick={handleLinkClick} />
-                <MenuSection title="BLOG" links={blogLinks} onLinkClick={handleLinkClick} />
-                <MenuSection
-                  title="ABOUT"
-                  links={showAAAPage ? [...aboutLinks, { label: "A³ Initiative", href: "/AAA" }] : aboutLinks}
-                  onLinkClick={handleLinkClick}
-                />
+              <div className={`grid grid-cols-2 ${desktopGridClass} gap-8 md:gap-12`}>
+                {sections.map((section) => (
+                  <MenuSection
+                    key={section.title}
+                    title={section.title}
+                    links={section.links}
+                    onLinkClick={handleLinkClick}
+                  />
+                ))}
               </div>
 
               {/* Bottom: Social Links or Newsletter */}

--- a/lib/config/content-visibility.ts
+++ b/lib/config/content-visibility.ts
@@ -1,0 +1,22 @@
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"])
+const FALSE_VALUES = new Set(["0", "false", "no", "off"])
+
+const parseBooleanEnv = (value: string | undefined, defaultValue: boolean) => {
+  if (typeof value !== "string") return defaultValue
+
+  const normalized = value.trim().toLowerCase()
+  if (TRUE_VALUES.has(normalized)) return true
+  if (FALSE_VALUES.has(normalized)) return false
+
+  return defaultValue
+}
+
+/**
+ * Public content switches.
+ * Defaults keep episodes visible while hiding editorial + artist writeups.
+ */
+export const publicContentVisibility = {
+  episodes: parseBooleanEnv(process.env.NEXT_PUBLIC_SHOW_EPISODES_CONTENT, true),
+  artists: parseBooleanEnv(process.env.NEXT_PUBLIC_SHOW_ARTISTS_CONTENT, false),
+  blog: parseBooleanEnv(process.env.NEXT_PUBLIC_SHOW_BLOG_CONTENT, false),
+}

--- a/lib/convex/server.ts
+++ b/lib/convex/server.ts
@@ -43,6 +43,10 @@ export async function getAllEpisodes() {
     return await convexClient.query(api.queries.getEpisodes, {});
 }
 
+export async function getEpisodeBySlug(slug: string) {
+    return await convexClient.query(api.queries.getEpisodeBySlug, { slug });
+}
+
 export async function getFeaturedArtists(limit = 3) {
     return await convexClient.query(api.queries.getArtists, {
         limit,
@@ -54,12 +58,20 @@ export async function getAllArtists() {
     return await convexClient.query(api.queries.getArtists, {});
 }
 
+export async function getArtistBySlug(slug: string) {
+    return await convexClient.query(api.queries.getArtistBySlug, { slug });
+}
+
 export async function getLatestBlogPosts(limit = 3) {
     return await convexClient.query(api.queries.getBlogPosts, { limit });
 }
 
 export async function getAllBlogPosts() {
     return await convexClient.query(api.queries.getBlogPosts, {});
+}
+
+export async function getBlogPostBySlug(slug: string) {
+    return await convexClient.query(api.queries.getBlogPostBySlug, { slug });
 }
 
 // ============================================

--- a/lib/repositories/content.ts
+++ b/lib/repositories/content.ts
@@ -6,8 +6,11 @@ export {
   getFeaturedEpisodes,
   getLatestEpisodes,
   getAllEpisodes,
+  getEpisodeBySlug,
   getFeaturedArtists,
   getAllArtists,
+  getArtistBySlug,
   getLatestBlogPosts,
   getAllBlogPosts,
+  getBlogPostBySlug,
 } from "@/lib/convex/server"


### PR DESCRIPTION
## Summary
- add centralized content visibility switches for public episodes, artists, and blog surfaces
- default to hiding artist and blog content while keeping episodes visible
- remove hardcoded fallback editorial/artist/generated content from public routes
- gate artists, blog, and slug pages behind visibility flags with 404 behavior when hidden
- hide artist and blog links in header, mega menu, and footer when disabled
- replace hardcoded artist/blog detail pages with CMS-backed rendering

## Validation
- npm run build